### PR TITLE
add differentiation between xpack and monitoring

### DIFF
--- a/lib/facter/heartbeat_version.rb
+++ b/lib/facter/heartbeat_version.rb
@@ -1,0 +1,8 @@
+Facter.add(:heartbeat_version) do
+  setcode do
+    if Facter::Core::Execution.which('heartbeat')
+      heartbeat_version = Facter::Core::Execution.execute('heartbeat version 2>&1')
+      %r{heartbeat version:?\s+v?([\w\.]+)}.match(heartbeat_version)[1]
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,8 +14,6 @@ class heartbeat::config {
     'name'                      => $heartbeat::beat_name ,
     'fields_under_root'         => $heartbeat::fields_under_root,
     'fields'                    => $heartbeat::fields,
-    'xpack'                     => $heartbeat::xpack,
-    'monitoring'                => $heartbeat::monitoring,
     'tags'                      => $heartbeat::tags,
     'queue'                     => $heartbeat::queue,
     'logging'                   => $heartbeat::logging,
@@ -27,12 +25,27 @@ class heartbeat::config {
     },
   })
 
+  if ($heartbeat::xpack != undef) and ($heartbeat::monitoring != undef) {
+    fail('Setting both xpack and monitoring is not supported!')
+  }
+
+  # Add the 'xpack' section if supported (version >= 6.2.0)
+  if (versioncmp($facts['heartbeat_version'], '7.2.0') >= 0) and ($heartbeat::monitoring) {
+    $merged_config = deep_merge($heartbeat_config, {'monitoring' => $heartbeat::monitoring})
+  }
+  elsif (versioncmp($facts['heartbeat_version'], '6.2.0') >= 0) and ($heartbeat::xpack) {
+    $merged_config = deep_merge($heartbeat_config, {'xpack' => $heartbeat::xpack})
+  }
+  else {
+    $merged_config = $heartbeat_config
+  }
+
   file { '/etc/heartbeat/heartbeat.yml':
     ensure       => $heartbeat::ensure,
     owner        => 'root',
     group        => 'root',
     mode         => $heartbeat::config_file_mode,
-    content      => inline_template('<%= @heartbeat_config.to_yaml()  %>'),
+    content      => inline_template('<%= @merged_config.to_yaml()  %>'),
     validate_cmd => $validate_cmd,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # Installs and configures heartbeat
 #
 # @summary Installs and configures heartbeat
-# 
+#
 # @example Basic configuration with two modules and output to Elasticsearch
 #  class{'heartbeat':
 #    monitors => [
@@ -79,7 +79,7 @@ class heartbeat (
   Optional[Variant[Stdlib::HTTPUrl, Stdlib::HTTPSUrl]] $gpg_key_url   = undef,
   String $gpg_key_id                                                  = '',
   Enum['enabled', 'running', 'disabled', 'unmanaged'] $service_ensure = 'enabled',
-  String $package_ensure                                              = 'latest',
+  String $package_ensure                                              = 'present',
   String $config_file_mode                                            = '0644',
   Boolean $disable_configtest                                         = false,
   Optional[Array[String]] $tags                                       = undef,

--- a/spec/classes/heartbeat_spec.rb
+++ b/spec/classes/heartbeat_spec.rb
@@ -15,7 +15,7 @@ describe 'heartbeat', 'type' => 'class' do
 
         it do
           is_expected.to contain_package('heartbeat-elastic').with(
-            'ensure' => 'latest',
+            'ensure' => 'present',
           )
         end
       end

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -6,3 +6,4 @@ ipaddress: "172.16.254.254"
 ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"
+heartbeat_version: "7.9.1"


### PR DESCRIPTION
since xpack is partially deprecated and will be removed soon, add xpack
support only on versions 6.2.0 until < 7.2.0, after that use monitoring
instead